### PR TITLE
fix sampler and fix_bn bugs and provide a faster triplet

### DIFF
--- a/opengait/data/sampler.py
+++ b/opengait/data/sampler.py
@@ -1,4 +1,5 @@
 import math
+import random
 import torch
 import torch.distributed as dist
 import torch.utils.data as tordata
@@ -49,7 +50,11 @@ class TripletSampler(tordata.sampler.Sampler):
 
 
 def sync_random_sample_list(obj_list, k):
-    idx = torch.randperm(len(obj_list))[:k]
+    if len(obj_list) < k:
+        idx = random.choices(range(len(obj_list)), k=k)
+        idx = torch.tensor(idx)
+    else:
+        idx = torch.randperm(len(obj_list))[:k]
     if torch.cuda.is_available():
         idx = idx.cuda()
     torch.distributed.broadcast(idx, src=0)

--- a/opengait/main.py
+++ b/opengait/main.py
@@ -44,6 +44,8 @@ def run_model(cfgs, training):
     model = Model(cfgs, training)
     if training and cfgs['trainer_cfg']['sync_BN']:
         model = nn.SyncBatchNorm.convert_sync_batchnorm(model)
+    if cfgs['trainer_cfg']['fix_BN']:
+        model.fix_BN()
     model = get_ddp_module(model)
     msg_mgr.log_info(params_count(model))
     msg_mgr.log_info("Model Initialization Finished!")

--- a/opengait/modeling/base_model.py
+++ b/opengait/modeling/base_model.py
@@ -167,10 +167,6 @@ class BaseModel(MetaModel, nn.Module):
         if restore_hint != 0:
             self.resume_ckpt(restore_hint)
 
-        if training:
-            if cfgs['trainer_cfg']['fix_BN']:
-                self.fix_BN()
-
     def get_backbone(self, backbone_cfg):
         """Get the backbone of the model."""
         if is_dict(backbone_cfg):
@@ -427,6 +423,8 @@ class BaseModel(MetaModel, nn.Module):
                     model.eval()
                     result_dict = BaseModel.run_test(model)
                     model.train()
+                    if model.cfgs['trainer_cfg']['fix_BN']:
+                        model.fix_BN()
                     model.msg_mgr.write_to_tensorboard(result_dict)
                     model.msg_mgr.reset_time()
             if model.iteration >= model.engine_cfg['total_iter']:


### PR DESCRIPTION
----------- sampler bug ------------
When len(obj_list) < k, there will be insufficient candidates for the old behavior. It may be the reason for #53.
For example, if we set batch-size to 32x16 and each person only has 5 sequences, the sample_indices would be 32x5 when applying the old sampler.

----------- Fix_BN ------------
`nn.SyncBatchNorm.convert_sync_batchnorm`  in [main.py#46](https://github.com/ShiqiYu/OpenGait/blob/0fb5c452728f8e61f041d6db5ef51898e5b8954c/opengait/main.py#L46) would reset the training status of BN, thus fix_BN should be called after it.
When `with_test` is set to true, `model.train()` in [base_model.py#429](https://github.com/ShiqiYu/OpenGait/blob/0fb5c452728f8e61f041d6db5ef51898e5b8954c/opengait/modeling/base_model.py#L429) would reset training status either.

----------- A fast triplet ------------
Compared to torch.where, mask indexing is almost 10x faster in our case and would be much faster when the `dist` matrix is larger. 
**It is worth noting that** if the samples are _strictly followed by the format PIDxSeq_, mask indexing would work well. But if each PID has different number of Seqs, mask indexing would meet a problem of data alignment. 

We make a comparsion of where_idx and mask_idx with following codes and settings.
>GPU: RTX 3090
>Batch Size: 32x16
>Strips in HP: 31

```python
import random
import timeit
import torch

def clock(func):
    repeat = 1000
    def clocked(*args, **kwargs):
        func(*args, **kwargs) # eliminate the GPU initial time
        start = timeit.default_timer()
        for _ in range(repeat):
            res = func(*args, **kwargs)
        run_time = timeit.default_timer() - start
        func_name = func.__name__
        print('Func %s     Repeat:%d     Total Time Cost>>>%0.8fs     Average Time Cost>>>%0.8fs' % (func_name, repeat, run_time, run_time/repeat))
        return res

    return clocked

@clock
def where_idx(row_labels, clo_label, dist):
        """
            row_labels: tensor with size [n_r]
            clo_label : tensor with size [n_c]
        """
        matches = (row_labels.unsqueeze(1) ==
                   clo_label.unsqueeze(0)).byte()  # [n_r, n_c]
        diffenc = matches ^ 1  # [n_r, n_c]
        mask = matches.unsqueeze(2) * diffenc.unsqueeze(1)
        a_idx, p_idx, n_idx = torch.where(mask)

        ap_dist = dist[:, a_idx, p_idx]
        an_dist = dist[:, a_idx, n_idx]
        return ap_dist, an_dist

@clock
def mask_idx(row_labels, clo_label, dist):
        """
            row_labels: tensor with size [n_r]
            clo_label : tensor with size [n_c]
        """
        matches = (row_labels.unsqueeze(1) == clo_label.unsqueeze(0)).bool() # [n_r, n_c]
        diffenc = torch.logical_not(matches) # [n_r, n_c]
        p, n, m = dist.size()
        ap_dist = dist[:, matches].view(p, n, -1, 1)
        an_dist = dist[:, diffenc].view(p, n, 1, -1)
        return ap_dist, an_dist


dist = torch.randn((31, 512, 512)).cuda()
labs = torch.arange(32).repeat(16)
idx = list(range(512))
random.shuffle(idx)
labs = labs[torch.tensor(idx)]

dist = dist.cuda()
labs = labs.cuda()

where_idx(labs, labs, dist)
mask_idx(labs, labs, dist)
```
We get the below results.

| Func         | Repeat          | Total Time Cost  | Average Time Cost |
| :-------------: |:-------------:| :-----:|:------: |
| where_idx       | 1000      | 16.42s | 0.01642s|
| mask_idx        | 1000      |   1.96s|0.00196s|
