### PR TITLE
Reconstruct LossAggregator and fix some typos in config files

### DIFF
--- a/configs/baseline/baseline_Gait3D.yaml
+++ b/configs/baseline/baseline_Gait3D.yaml
@@ -83,7 +83,7 @@ trainer_cfg:
   enable_float16: true # half_percesion float for memory reduction and speedup
   fix_BN: false
   log_iter: 100
-  with_test: 10000
+  with_test: true
   restore_ckpt_strict: true
   restore_hint: 0
   save_iter: 10000

--- a/configs/smplgait/smplgait.yaml
+++ b/configs/smplgait/smplgait.yaml
@@ -85,7 +85,7 @@ trainer_cfg:
   enable_float16: true # half_percesion float for memory reduction and speedup
   fix_BN: false
   log_iter: 100
-  with_test: 10000
+  with_test: true
   restore_ckpt_strict: true
   restore_hint: 0
   save_iter: 10000

--- a/opengait/modeling/loss_aggregator.py
+++ b/opengait/modeling/loss_aggregator.py
@@ -21,7 +21,7 @@ class LossAggregator(nn.Module):
     """
     def __init__(self, loss_cfg) -> None:
         """
-        Initialize the loss aggregator. 
+        Initialize the loss aggregator.
 
         LossAggregator can be indexed like a regular Python dictionary, 
         but modules it contains are properly registered, and will be visible by all Module methods.


### PR DESCRIPTION
1. new config files brought by Gait3D have some typos
2. The old LossAggregator is a basic python class that cannot register parameters to the base_model. It is inconvenient to train models with those losses that require parameters, such as center loss.  
Therefore, it seems a better way that registers LossAggregator as an `nn.Module` and uses `nn.ModuleDict` to organize all losses.
**In this new version,**
LossAggregator can be indexed like a regular Python dictionary (keep it the same as the current version), 
but the modules it contains are properly registered and will be visible by all Module methods.
All parameters registered in losses can be accessed by the method 'self.parameters()', enabling they can be trained properly.