### PR TITLE
Eliminate Deprecation by replacing `torch.distributed.launch` with `torchrun`

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,32 +1,91 @@
 # # **************** For CASIA-B ****************
 # # Baseline
-CUDA_VISIBLE_DEVICES=0,1 python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/baseline/baseline.yaml --phase test
+CUDA_VISIBLE_DEVICES=0,1 
+torchrun --nproc_per_node=2 opengait/main.py --cfgs ./configs/baseline/baseline.yaml --phase test
 
 # # GaitSet
-# CUDA_VISIBLE_DEVICES=0,1 python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/gaitset/gaitset.yaml --phase test
+# CUDA_VISIBLE_DEVICES=0,1
+# torchrun --nproc_per_node=2 opengait/main.py --cfgs ./configs/gaitset/gaitset.yaml --phase test
 
 # # GaitPart
-# CUDA_VISIBLE_DEVICES=0,1 python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/gaitpart/gaitpart.yaml --phase test
+# CUDA_VISIBLE_DEVICES=0,1
+# torchrun --nproc_per_node=2 opengait/main.py --cfgs ./configs/gaitpart/gaitpart.yaml --phase test
 
 # GaitGL
-# CUDA_VISIBLE_DEVICES=0,1,2,3 python -m torch.distributed.launch --master_port 12345 --nproc_per_node=4 opengait/main.py --cfgs ./configs/gaitgl/gaitgl.yaml --phase test
+# CUDA_VISIBLE_DEVICES=0,1,2,3 
+# torchrun --master_port 12345 --nproc_per_node=4 opengait/main.py --cfgs ./configs/gaitgl/gaitgl.yaml --phase test
 
 # # GLN 
 # # Phase 1
-# CUDA_VISIBLE_DEVICES=3,4 python -m torch.distributed.launch --master_port 12345  --nproc_per_node=2 opengait/main.py --cfgs ./configs/gln/gln_phase1.yaml --phase test
+# CUDA_VISIBLE_DEVICES=3,4 
+# torchrun --master_port 12345  --nproc_per_node=2 opengait/main.py --cfgs ./configs/gln/gln_phase1.yaml --phase test
 # # Phase 2
-# CUDA_VISIBLE_DEVICES=2,5 python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/gln/gln_phase2.yaml --phase test
+# CUDA_VISIBLE_DEVICES=2,5 
+# torchrun --nproc_per_node=2 opengait/main.py --cfgs ./configs/gln/gln_phase2.yaml --phase test
 
 
 # # **************** For OUMVLP ****************
 # # Baseline
-# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/baseline/baseline_OUMVLP.yaml --phase test
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# torchrun --nproc_per_node=8 opengait/main.py --cfgs ./configs/baseline/baseline_OUMVLP.yaml --phase test
 
 # # GaitSet
-# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitset/gaitset_OUMVLP.yaml --phase test
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# torchrun --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitset/gaitset_OUMVLP.yaml --phase test
 
 # # GaitPart
-# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitpart/gaitpart_OUMVLP.yaml --phase test
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 
+# torchrun --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitpart/gaitpart_OUMVLP.yaml --phase test
 
 # GaitGL
-# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitgl/gaitgl_OUMVLP.yaml --phase test
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# torchrun --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitgl/gaitgl_OUMVLP.yaml --phase test
+
+
+############################################################################################################################################################################
+#                                              The scripts using `torch.distributed.launch` below has been deprecated                                                      #
+############################################################################################################################################################################
+
+
+# # **************** For CASIA-B ****************
+# # Baseline
+# CUDA_VISIBLE_DEVICES=0,1 
+# python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/baseline/baseline.yaml --phase test
+
+# # GaitSet
+# CUDA_VISIBLE_DEVICES=0,1 
+# python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/gaitset/gaitset.yaml --phase test
+
+# # GaitPart
+# CUDA_VISIBLE_DEVICES=0,1 
+# python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/gaitpart/gaitpart.yaml --phase test
+
+# GaitGL
+# CUDA_VISIBLE_DEVICES=0,1,2,3 
+# python -m torch.distributed.launch --master_port 12345 --nproc_per_node=4 opengait/main.py --cfgs ./configs/gaitgl/gaitgl.yaml --phase test
+
+# # GLN 
+# # Phase 1
+# CUDA_VISIBLE_DEVICES=3,4 
+# python -m torch.distributed.launch --master_port 12345  --nproc_per_node=2 opengait/main.py --cfgs ./configs/gln/gln_phase1.yaml --phase test
+# # Phase 2
+# CUDA_VISIBLE_DEVICES=2,5 
+# python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/gln/gln_phase2.yaml --phase test
+
+
+# # **************** For OUMVLP ****************
+# # Baseline
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 
+# python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/baseline/baseline_OUMVLP.yaml --phase test
+
+# # GaitSet
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 
+# python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitset/gaitset_OUMVLP.yaml --phase test
+
+# # GaitPart
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 
+# python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitpart/gaitpart_OUMVLP.yaml --phase test
+
+# GaitGL
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 
+# python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitgl/gaitgl_OUMVLP.yaml --phase test

--- a/train.sh
+++ b/train.sh
@@ -1,32 +1,91 @@
 # # **************** For CASIA-B ****************
 # # Baseline
-CUDA_VISIBLE_DEVICES=0,1 python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/baseline/baseline.yaml --phase train
+CUDA_VISIBLE_DEVICES=0,1
+torchrun --nproc_per_node=2 opengait/main.py --cfgs ./configs/baseline/baseline.yaml --phase train
 
 # # GaitSet
-# CUDA_VISIBLE_DEVICES=0,1 python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/gaitset/gaitset.yaml --phase train
+# CUDA_VISIBLE_DEVICES=0,1
+# torchrun --nproc_per_node=2 opengait/main.py --cfgs ./configs/gaitset/gaitset.yaml --phase train
 
 # # GaitPart
-# CUDA_VISIBLE_DEVICES=0,1 python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/gaitpart/gaitpart.yaml --phase train
+# CUDA_VISIBLE_DEVICES=0,1
+# torchrun --nproc_per_node=2 opengait/main.py --cfgs ./configs/gaitpart/gaitpart.yaml --phase train
 
 # GaitGL
-# CUDA_VISIBLE_DEVICES=0,1,2,3 python -m torch.distributed.launch --nproc_per_node=4 opengait/main.py --cfgs ./configs/gaitgl/gaitgl.yaml --phase train
+# CUDA_VISIBLE_DEVICES=0,1,2,3
+# torchrun --nproc_per_node=4 opengait/main.py --cfgs ./configs/gaitgl/gaitgl.yaml --phase train
 
 # # GLN 
 # # Phase 1
-# CUDA_VISIBLE_DEVICES=2,5,6,7 python -m torch.distributed.launch --nproc_per_node=4 opengait/main.py --cfgs ./configs/gln/gln_phase1.yaml --phase train
+# CUDA_VISIBLE_DEVICES=2,5,6,7
+# torchrun --nproc_per_node=4 opengait/main.py --cfgs ./configs/gln/gln_phase1.yaml --phase train
 # # Phase 2
-# CUDA_VISIBLE_DEVICES=2,5,6,7 python -m torch.distributed.launch --nproc_per_node=4 opengait/main.py --cfgs ./configs/gln/gln_phase2.yaml --phase train
+# CUDA_VISIBLE_DEVICES=2,5,6,7
+# torchrun --nproc_per_node=4 opengait/main.py --cfgs ./configs/gln/gln_phase2.yaml --phase train
 
 
 # # **************** For OUMVLP ****************
 # # Baseline
-# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/baseline/baseline_OUMVLP.yaml --phase train
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# torchrun --nproc_per_node=8 opengait/main.py --cfgs ./configs/baseline/baseline_OUMVLP.yaml --phase train
 
 # # GaitSet
-# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitset/gaitset_OUMVLP.yaml --phase train
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# torchrun --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitset/gaitset_OUMVLP.yaml --phase train
 
 # # GaitPart
-# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitpart/gaitpart_OUMVLP.yaml --phase train
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# torchrun --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitpart/gaitpart_OUMVLP.yaml --phase train
 
 # GaitGL
-# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitgl/gaitgl_OUMVLP.yaml --phase train
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# torchrun --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitgl/gaitgl_OUMVLP.yaml --phase train
+
+
+############################################################################################################################################################################
+#                                              The scripts using `torch.distributed.launch` below has been deprecated                                                      #
+############################################################################################################################################################################
+
+
+# # **************** For CASIA-B ****************
+# # Baseline
+# CUDA_VISIBLE_DEVICES=0,1
+# python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/baseline/baseline.yaml --phase train
+
+# # GaitSet
+# CUDA_VISIBLE_DEVICES=0,1 
+# python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/gaitset/gaitset.yaml --phase train
+
+# # GaitPart
+# CUDA_VISIBLE_DEVICES=0,1 
+# python -m torch.distributed.launch --nproc_per_node=2 opengait/main.py --cfgs ./configs/gaitpart/gaitpart.yaml --phase train
+
+# GaitGL
+# CUDA_VISIBLE_DEVICES=0,1,2,3 
+# python -m torch.distributed.launch --nproc_per_node=4 opengait/main.py --cfgs ./configs/gaitgl/gaitgl.yaml --phase train
+
+# # GLN 
+# # Phase 1
+# CUDA_VISIBLE_DEVICES=2,5,6,7
+# python -m torch.distributed.launch --nproc_per_node=4 opengait/main.py --cfgs ./configs/gln/gln_phase1.yaml --phase train
+# # Phase 2
+# CUDA_VISIBLE_DEVICES=2,5,6,7
+# python -m torch.distributed.launch --nproc_per_node=4 opengait/main.py --cfgs ./configs/gln/gln_phase2.yaml --phase train
+
+
+# # **************** For OUMVLP ****************
+# # Baseline
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/baseline/baseline_OUMVLP.yaml --phase train
+
+# # GaitSet
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitset/gaitset_OUMVLP.yaml --phase train
+
+# # GaitPart
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitpart/gaitpart_OUMVLP.yaml --phase train
+
+# GaitGL
+# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# python -m torch.distributed.launch --nproc_per_node=8 opengait/main.py --cfgs ./configs/gaitgl/gaitgl_OUMVLP.yaml --phase train


### PR DESCRIPTION
Got a deprecation warning when executing `train.sh` and `test.sh`:

```shell
....../torch/distributed/launch.py:181: FutureWarning: The module torch.distributed.launch is deprecated and will be removed in future. Use torchrun.
```

`torch.distributed.launch` is deprecated with `torch` as it's alternative tool. 

Where `torchrun` provides a **superset** of the functionality as `torch.distributed.launch` with the following additional functionalities:

1. Worker failures are handled gracefully by restarting all workers.
2. Worker RANK and WORLD_SIZE are assigned automatically.
3. Number of nodes is allowed to change between minimum and maximum sizes (elasticity).

See more [here](https://pytorch.org/docs/stable/elastic/run.html)