### PR TITLE
Minor bugfix: evaluator_cfg transform type for DeepGaitV2_gait3d.yaml

### DIFF
--- a/configs/deepgaitv2/DeepGaitV2_gait3d.yaml
+++ b/configs/deepgaitv2/DeepGaitV2_gait3d.yaml
@@ -19,7 +19,7 @@ evaluator_cfg:
     frames_all_limit: 720 # limit the number of sampled frames to prevent out of memory
   metric: euc # cos
   transform:
-    - type: BaseSilTransform
+    - type: BaseSilCuttingTransform
 
 loss_cfg:
   - loss_term_weight: 1.0


### PR DESCRIPTION
## Description
Hello,

I encountered the following error when testing the `DeepGaitV2` model on `Gait3D` dataset:

```python
File "/home/SCienceVessel/OpenGait/opengait/modeling/models/deepgaitv2.py", line 103, in forward
    assert sils.size(-1) in [44, 88]
```

This error occurs because the default transform type provided in the config file for the evaluator is `BaseSilTransform` instead of `BaseSilCuttingTransform`. As a result, the input data are not cropped from `64*64` to `64*44`. I suppose this is a typo as all other Gait3D-related configs are correct.

## Change Made
- Changed the evaluator transform type from `BaseSilTransform` to `BaseSilCuttingTransform` in `DeepGaitV2_gait3d.yaml`.