### PR TITLE
Update 0.get_started.md

### DIFF
--- a/docs/0.get_started.md
+++ b/docs/0.get_started.md
@@ -1,36 +1,43 @@
 # Get Started
 ## Installation
 1. clone this repo.
-    ```
+    ```bash
     git clone https://github.com/ShiqiYu/OpenGait.git
     ```
 2. Install dependenices:
-    - pytorch >= 1.10
-    - torchvision
-    - pyyaml
-    - tensorboard
-    - opencv-python
-    - tqdm
-    - py7zr
-    - kornia
-    - einops
-  
-    Install dependenices by [Anaconda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html):
-    ```
-    conda install tqdm pyyaml tensorboard opencv kornia einops -c conda-forge
-    conda install pytorch==1.10 torchvision -c pytorch
-    ```    
-    Or, Install dependenices by pip:
-    ```
-    pip install tqdm pyyaml tensorboard opencv-python kornia einops
-    pip install torch==1.10 torchvision==0.11
-    ```
+    - Create a requirements.txt and add the given below dependency
+       ```text
+        pytorch >= 1.10
+        torchvision
+        pyyaml
+        tensorboard
+        opencv-python
+        tqdm
+        py7zr
+        kornia
+        einops
+      ```
+     - Run in terminal or cmd after activating virtual environment
+        ```bash
+          pip install -r requirements.txt
+        ```
+
+    - Install dependenices by [Anaconda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html):
+      ```bash
+      conda install tqdm pyyaml tensorboard opencv kornia einops -c conda-forge
+      conda install pytorch==1.10 torchvision -c pytorch
+      ```    
+    - Or, Install dependenices by pip:
+        ```bash
+        pip install tqdm pyyaml tensorboard opencv-python kornia einops
+        pip install torch==1.10 torchvision==0.11
+        ```
 ## Prepare dataset
 See [prepare dataset](2.prepare_dataset.md).
 
 ## Get trained model
 - Option 1:
-    ```
+    ```bash
     python misc/download_pretrained_model.py
     ```
 - Option 2: Go to the [release page](https://github.com/ShiqiYu/OpenGait/releases/), then download the model file and uncompress it to [output](output).


### PR DESCRIPTION
Updated the documentation to replace the manual "one-by-one" dependency installation steps with the standard `pip install -r requirements.txt` command.